### PR TITLE
Implement list logs command

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.Person;
 
 /**
@@ -32,6 +33,9 @@ public interface Logic {
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();
+
+    /** Returns an unmodifiable view of the filtered list of logs */
+    ObservableList<Log> getFilteredSessionLog();
 
     /**
      * Returns the user prefs' address book file path.

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -15,6 +15,7 @@ import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.Person;
 import seedu.address.storage.Storage;
 
@@ -71,6 +72,10 @@ public class LogicManager implements Logic {
         return model.getFilteredPersonList();
     }
 
+    @Override
+    public ObservableList<Log> getFilteredSessionLog() {
+        return model.getFilteredLogList();
+    }
     @Override
     public Path getAddressBookFilePath() {
         return model.getAddressBookFilePath();

--- a/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
@@ -33,9 +33,9 @@ public class ListLogsCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         //TODO: Handle behaviour later
         requireNonNull(model);
-        // Temporary stub
-        model.updateFilteredLogsListById(this.identityNumber);
-        return new CommandResult("The NRIC you inputted is: " + this.identityNumber.toString());
+        model.updateFilteredLogListById(this.identityNumber);
+        return new CommandResult("The NRIC you inputted is: " + this.identityNumber.toString()
+        + "\n" + "The logs for this person are: " + model.getFilteredLogList().toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.IdentityNumber;
 
 /**
@@ -34,8 +35,17 @@ public class ListLogsCommand extends Command {
         //TODO: Handle behaviour later
         requireNonNull(model);
         model.updateFilteredLogListById(this.identityNumber);
-        return new CommandResult("The NRIC you inputted is: " + this.identityNumber.toString()
-        + "\n" + "The logs for this person are: " + model.getFilteredLogList().toString());
+
+        StringBuilder sb = new StringBuilder();
+        sb.append("The NRIC you inputted is: ").append(this.identityNumber.toString()).append("\n");
+        sb.append("The logs for this person are:\n");
+
+        for (Log log : model.getFilteredLogList()) {
+            sb.append("Appointment Date: ").append(log.getAppointmentDate())
+                    .append(", Entry: ").append(log.getEntry()).append("\n");
+        }
+
+        return new CommandResult(sb.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
@@ -1,5 +1,7 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.person.IdentityNumber;
@@ -29,13 +31,11 @@ public class ListLogsCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        throw new CommandException("ListLogsCommand not implemented yet");
-
         //TODO: Handle behaviour later
-        //requireNonNull(model);
+        requireNonNull(model);
         // Temporary stub
-        //model.updateFilteredLogsListById(this.identityNumber);
-        //return new CommandResult("The NRIC you inputted is: " + "nric");
+        model.updateFilteredLogsListById(this.identityNumber);
+        return new CommandResult("The NRIC you inputted is: " + this.identityNumber.toString());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -23,6 +23,7 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
 
         // Manually checking if required prefixes are present
         if (argMultimap.getValue(PREFIX_IDENTITY_NUMBER).isEmpty() || argMultimap.getValue(PREFIX_LOG).isEmpty()) {
+            System.out.println("failhere");
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
         }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -97,7 +97,8 @@ public interface Model {
      */
     void updateFilteredPersonListById(IdentityNumber identityNumber);
 
-    void updateFilteredLogList(Predicate<Log> predicate);
-
     void updateFilteredLogListById(IdentityNumber identityNumber);
+
+    // DO NOT USE, added by ZR to prepare for future abstraction
+    void updateFilteredLogList(Predicate<Log> predicate);
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.IdentityNumber;
 import seedu.address.model.person.Person;
 
@@ -81,6 +82,9 @@ public interface Model {
     /** Returns an unmodifiable view of the filtered person list */
     ObservableList<Person> getFilteredPersonList();
 
+    /** Returns an unmodifiable view of the filtered log list */
+    ObservableList<Log> getFilteredLogList();
+
     /**
      * Updates the filter of the filtered person list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
@@ -91,5 +95,9 @@ public interface Model {
      * Updates the filter of the logs list to filter by the given {@code identityNumber}.
      * @param identityNumber
      */
-    void updateFilteredLogsListById(IdentityNumber identityNumber);
+    void updateFilteredPersonListById(IdentityNumber identityNumber);
+
+    void updateFilteredLogList(Predicate<Log> predicate);
+
+    void updateFilteredLogListById(IdentityNumber identityNumber);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -7,10 +7,12 @@ import java.nio.file.Path;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
+import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.IdentityNumber;
 import seedu.address.model.person.Person;
 
@@ -24,6 +26,10 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
 
+    // FilteredLogs should be final? Note that it is not initalised,
+    // may cause run time error. TODO: Improve on stability
+    private FilteredList<Log> filteredLogs;
+
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
      */
@@ -34,7 +40,7 @@ public class ModelManager implements Model {
 
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
-        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        filteredPersons = new FilteredList<>(this.addressBook.getPersonList());;
     }
 
     public ModelManager() {
@@ -123,10 +129,24 @@ public class ModelManager implements Model {
         return filteredPersons;
     }
 
+    /**
+     * Returns an unmodifiable view of the list of {@code Log} backed by the internal list of
+     * {@code versionedAddressBook}
+     */
+    @Override
+    public ObservableList<Log> getFilteredLogList() {
+        return filteredLogs;
+    }
+
     @Override
     public void updateFilteredPersonList(Predicate<Person> predicate) {
         requireNonNull(predicate);
         filteredPersons.setPredicate(predicate);
+    }
+    @Override
+    public void updateFilteredLogList(Predicate<Log> predicate) {
+        requireNonNull(predicate);
+        filteredLogs.setPredicate(predicate);
     }
 
     /**
@@ -135,10 +155,24 @@ public class ModelManager implements Model {
      * @param identityNumber
      */
     @Override
-    public void updateFilteredLogsListById(IdentityNumber identityNumber) {
+    public void updateFilteredPersonListById(IdentityNumber identityNumber) {
         requireNonNull(identityNumber);
         Predicate<Person> predicate = person -> person.getIdentityNumber().equals(identityNumber);
         updateFilteredPersonList(predicate);
+    }
+
+    public void updateFilteredLogListById(IdentityNumber identityNumber) {
+        requireNonNull(identityNumber);
+
+        // Get the person with matching identity number
+        updateFilteredPersonListById(identityNumber);
+        Person targetPerson = filteredPersons.get(0);
+
+        // Convert Set<Log> to an ObservableList<Log>
+        ObservableList<Log> loglist = FXCollections.observableArrayList(targetPerson.getLogs());
+
+        // Update the FilteredLogs to the logs of the targetPerson
+        filteredLogs = new FilteredList<>(loglist);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -161,6 +161,11 @@ public class ModelManager implements Model {
         updateFilteredPersonList(predicate);
     }
 
+    /**
+     * Updates logs list to show logs identified by the given {@code identityNumber}.
+     *
+     * @param identityNumber
+     */
     public void updateFilteredLogListById(IdentityNumber identityNumber) {
         requireNonNull(identityNumber);
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -22,6 +22,7 @@ import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
+import seedu.address.model.log.Log;
 import seedu.address.model.person.IdentityNumber;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.PersonBuilder;
@@ -154,6 +155,14 @@ public class AddCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        /**
+         * Returns an unmodifiable view of the filtered log list
+         */
+        @Override
+        public ObservableList<Log> getFilteredLogList() {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void updateFilteredPersonList(Predicate<Person> predicate) {
             throw new AssertionError("This method should not be called.");
@@ -166,6 +175,16 @@ public class AddCommandTest {
          */
         @Override
         public void updateFilteredPersonListById(IdentityNumber identityNumber) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredLogList(Predicate<Log> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateFilteredLogListById(IdentityNumber identityNumber) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -165,7 +165,7 @@ public class AddCommandTest {
          * @param identityNumber
          */
         @Override
-        public void updateFilteredLogsListById(IdentityNumber identityNumber) {
+        public void updateFilteredPersonListById(IdentityNumber identityNumber) {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
This commit violates many SE principles since adding this requires a deep refactoring.
As such a short circuiting method is done to meet the deadline for MVP feature.

1. It relies on updating the person list via IdentityNumber
2. Get the person from index 0 and its corresponding logs
3. The appointment date as well as details will be displayed within the small feedback window with the main
   filteredPersonList remaining the same


For future implementation, it should use predicates and its own function instead of that of getFilteredPerson.