### PR TITLE
Differentiate invalid Id within AddLogCommand

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -28,6 +28,7 @@ public class AddLogCommand extends Command {
 
     public static final String MESSAGE_ADD_LOG_SUCCESS = "Added log for Person: %1$s";
     public static final String MESSAGE_PERSON_NOT_FOUND = "Person with ID %1$s not found.";
+    public static final String MESSAGE_INVALID_ID = "Invalid ID.";
 
 
     private final IdentityNumber identityNumber;

--- a/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddLogCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser;
 
 import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.commands.AddLogCommand.MESSAGE_INVALID_ID;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_IDENTITY_NUMBER;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_LOG;
@@ -27,33 +28,35 @@ public class AddLogCommandParser implements Parser<AddLogCommand> {
 
         argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_IDENTITY_NUMBER, PREFIX_LOG, PREFIX_DATE);
 
+        // Check if all fields' prefix are present
         if (argMultimap.getValue(PREFIX_IDENTITY_NUMBER).isEmpty() || argMultimap.getValue(PREFIX_LOG).isEmpty()
                 || argMultimap.getValue(PREFIX_DATE).isEmpty()) {
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE));
         }
 
+        IdentityNumber identityNumber;
+
+        // Check if identity number exists
         try {
             // Parse identity number
-            IdentityNumber identityNumber = ParserUtil.parseIdentityNumber(
+            identityNumber = ParserUtil.parseIdentityNumber(
                     argMultimap.getValue(PREFIX_IDENTITY_NUMBER).get());
-
-            // Parse date
-            String date = argMultimap.getValue(PREFIX_DATE).get();
-            AppointmentDate appointmentDate = new AppointmentDate(date);
-
-            // Parse log
-            String entry = argMultimap.getValue(PREFIX_LOG).get();
-
-            // Create log object
-            Log log = new Log(appointmentDate, entry);
-
-            // Create and return AddLogCommand with parsed values
-            return new AddLogCommand(identityNumber, log);
-
         } catch (ParseException pe) {
-            throw new ParseException(
-                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddLogCommand.MESSAGE_USAGE), pe);
+            throw new ParseException(MESSAGE_INVALID_ID);
         }
+
+        // Parse date
+        String date = argMultimap.getValue(PREFIX_DATE).get();
+        AppointmentDate appointmentDate = new AppointmentDate(date);
+
+        // Parse log
+        String entry = argMultimap.getValue(PREFIX_LOG).get();
+
+        // Create log object
+        Log log = new Log(appointmentDate, entry);
+
+        // Create and return AddLogCommand with parsed values
+        return new AddLogCommand(identityNumber, log);
     }
 }


### PR DESCRIPTION
Closes #112 
- Provide more detailed and accurate error message for AddLogCommand

Has to be done in parser instead of previously implemented within AddLogCommand to prevent ParseException from propagating which makes it hard to differentiate from incorrect format.

