### PR TITLE
Add Log to UML Model Class Diagram

### DIFF
--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -19,6 +19,7 @@ Class Email
 Class Name
 Class Phone
 Class Tag
+Class Log
 
 Class I #FFFFFF
 }
@@ -42,6 +43,7 @@ Person *--> Phone
 Person *--> Email
 Person *--> Address
 Person *--> "*" Tag
+Person *---> "*" Log
 
 Person -[hidden]up--> I
 UniquePersonList -[hidden]right-> I


### PR DESCRIPTION
closes #140 


Adding a downward link [`-->`] makes the Arrow/Composition Arrow cluttered together.
Unsuitable to use left/right arrows as well as it does not give reflect the hierarchical nature.

Was not able to find a suitable combination of invisible arrows that makes everything level.

So far, the best looking result I've got was to add a downward long link [`--->`] from Person to Log. However, the issue with it is that it makes `Log` one level lower than the other classes associated with `Person`.