### PR TITLE
Fix person attribute hierachy

### DIFF
--- a/docs/diagrams/ModelClassDiagram.puml
+++ b/docs/diagrams/ModelClassDiagram.puml
@@ -3,6 +3,7 @@
 skinparam arrowThickness 1.1
 skinparam arrowColor MODEL_COLOR
 skinparam classBackgroundColor MODEL_COLOR
+skinparam linetype ortho
 
 Package Model as ModelPackage <<Rectangle>>{
 Class "<<interface>>\nReadOnlyAddressBook" as ReadOnlyAddressBook
@@ -39,13 +40,15 @@ UserPrefs .up.|> ReadOnlyUserPrefs
 
 AddressBook *--> "1" UniquePersonList
 UniquePersonList --> "~* all" Person
+
+' Adjust the exit points of diamonds from the Person class to avoid clutter
 Person *--> Name
 Person *--> Phone
 Person *--> IdentityNumber
 Person *--> Email
 Person *--> Address
 Person *--> "*" Tag
-Person *---> "*" Log
+Person *--> "*" Log
 
 Person -[hidden]up--> I
 UniquePersonList -[hidden]right-> I
@@ -53,6 +56,9 @@ UniquePersonList -[hidden]right-> I
 Name -[hidden]right-> Phone
 Phone -[hidden]right-> Address
 Address -[hidden]right-> Email
+Email -[hidden]right-> IdentityNumber
+IdentityNumber -[hidden]right-> Tag
+Tag -[hidden]right-> Log
 
 ModelManager --> "~* filtered" Person
 @enduml


### PR DESCRIPTION
closes #150 

- Before: overlap of diagmond arrows + Log on different level
![image](https://github.com/user-attachments/assets/4c3f8b92-061f-48b5-a786-b9234f19c9ae)

- After: Orthogonal lines to make it cleaner but overlap can't really be fixed**
![image](https://github.com/user-attachments/assets/c3a7c357-d37a-4981-96ce-c67099014393)

Seems to be impossible to achieve both. Either you keep all along the same level but overlap diamonds or lengthen the outside classes such that they extend from the side
