### PR TITLE
Change Help Window's User Guide URL to team's URL

### DIFF
--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -15,7 +15,7 @@ import seedu.address.commons.core.LogsCenter;
  */
 public class HelpWindow extends UiPart<Stage> {
 
-    public static final String USERGUIDE_URL = "https://se-education.org/addressbook-level3/UserGuide.html";
+    public static final String USERGUIDE_URL = "https://ay2425s1-cs2103t-w13-3.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide: " + USERGUIDE_URL;
 
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);


### PR DESCRIPTION
closes #196 

![image](https://github.com/user-attachments/assets/9e3eab56-acc8-4fd1-977c-5e75c306ce81)

A simple fix that only displays the correct link. Given the time line, we might not be able to complete issue #70 
