### PR TITLE
Add ability for ui to refresh upon adding a new log

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -47,9 +47,11 @@ public class AddLogCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Person personToUpdate = getPerson(model);
+        int personIndex = model.getPersonList().indexOf(personToUpdate);
         model.addLog(personToUpdate, log);
 
-        return new CommandResult(String.format(MESSAGE_ADD_LOG_SUCCESS, personToUpdate.getName()));
+        return new CommandResult(String.format(MESSAGE_ADD_LOG_SUCCESS, personToUpdate.getName()),
+                false, false, false, false, personIndex, false, true);
     }
 
     private Person getPerson(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -20,13 +20,16 @@ public class CommandResult {
     private final boolean exit;
 
     /** The application should list the logs. */
-    private final boolean list;
+    private final boolean listLogs;
 
-    // ^ NEW: might not the best as well, but there is a need to bring out more information
-    // to the GUI layer so we can update and reflect the sessionlog. please think of a better way
+    /** The application should list the person list. */
+    private final boolean isPersonList;
 
-    /** The application should use the index returned. */ // NEW: I dont think this is a good implementation.
+    /** The application should use the index returned. */
     private final int personIndex;
+
+    /** The application should refresh the session log accordingly. */
+    private final boolean isAddLog;
 
     /** The previous command prompts the user for confirmation */
     private final boolean hasPrompt;
@@ -36,13 +39,15 @@ public class CommandResult {
      */
 
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean isPrompt,
-                         boolean list, int personIndex) {
+                         boolean list, int personIndex, boolean isPersonList, boolean isAddLog) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
-        this.list = list;
+        this.listLogs = list;
         this.personIndex = personIndex;
         this.hasPrompt = isPrompt;
+        this.isPersonList = isPersonList;
+        this.isAddLog = isAddLog;
     }
 
 
@@ -51,7 +56,15 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false, false, -1);
+        this(feedbackToUser, false, false, false, false, -1, false, false);
+    }
+
+    /**
+     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
+     * and other fields set to their default value except {@code isPersonList} set to false.
+     */
+    public CommandResult(String feedbackToUser, boolean isPersonList) {
+        this(feedbackToUser, false, false, false, false, -1, isPersonList, false);
     }
 
     public String getFeedbackToUser() {
@@ -67,13 +80,20 @@ public class CommandResult {
     }
 
 
-    public boolean isList() {
-        return list;
+    public boolean isListLogs() {
+        return listLogs;
     }
 
-    // might need more validation to check if personIndex > -1 before retrieving?
     public int getPersonIndex() {
         return personIndex;
+    }
+
+    public boolean isAddLog() {
+        return isAddLog;
+    }
+
+    public boolean isPersonList() {
+        return isPersonList;
     }
 
 
@@ -96,14 +116,16 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && list == otherCommandResult.list
+                && listLogs == otherCommandResult.listLogs
                 && personIndex == otherCommandResult.personIndex
-                && hasPrompt == otherCommandResult.hasPrompt;
+                && hasPrompt == otherCommandResult.hasPrompt
+                && isPersonList == otherCommandResult.isPersonList
+                && isAddLog == otherCommandResult.isAddLog;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, list, personIndex, hasPrompt);
+        return Objects.hash(feedbackToUser, showHelp, exit, listLogs, personIndex, hasPrompt, isPersonList, isAddLog);
     }
 
     @Override
@@ -113,8 +135,10 @@ public class CommandResult {
                 .add("showHelp", showHelp)
                 .add("exit", exit)
                 .add("prompt", hasPrompt)
-                .add("list", list)
+                .add("list", listLogs)
                 .add("personIndex", personIndex)
+                .add("isPersonList", isPersonList)
+                .add("isAddLog", isAddLog)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/ConfirmPrompt.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmPrompt.java
@@ -24,7 +24,7 @@ public class ConfirmPrompt extends Command {
         savedCommand.validateInput(model);
         model.setSavedCommand(savedCommand);
 
-        return new CommandResult(MESSAGE_CONFIRM_PROMPT, false, false, true, false, -1);
+        return new CommandResult(MESSAGE_CONFIRM_PROMPT, false, false, true, false, -1, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, -1);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, -1, false, false);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1, false, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,6 +19,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS);
+        return new CommandResult(MESSAGE_SUCCESS, false, false,
+                false, false, -1, true, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
@@ -71,7 +71,7 @@ public class ListLogsCommand extends Command {
         model.getSessionLog(personIndex);
         return new CommandResult(String.format(MESSAGE_LIST_LOG_SUCCESS,
                 person.getName(), identityNumber),
-                false, false, false, true, personIndex);
+                false, false, false, true, personIndex, false, false);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CentralDisplay.java
+++ b/src/main/java/seedu/address/ui/CentralDisplay.java
@@ -15,9 +15,11 @@ public class CentralDisplay extends UiPart<Region> {
 
     private static final String FXML = "CentralDisplay.fxml";
 
-    private Logic logic;
+    private final Logic logic;
     private PersonListPanel personListPanel;
     private SessionLogPanel sessionLogPanel;
+
+    private int currentPersonLogIndex;
 
     @FXML
     private StackPane personListPanelPlaceholder;
@@ -76,17 +78,34 @@ public class CentralDisplay extends UiPart<Region> {
     }
 
 
+
+    /**
+     * Updates the session log whenever a new entry is added for the session log currently on display.
+     */
+    public void handleLogRefresh(int personIndex) {
+        requireNonNull(personIndex);
+        assert personIndex > -1 : "Person index retrieved is less than 0";
+
+        if (currentPersonLogIndex != personIndex || !sessionLogPanelPlaceholder.isVisible()) {
+            return;
+        }
+
+        sessionLogPanel = new SessionLogPanel(logic.getSessionLog(personIndex));
+        sessionLogPanelPlaceholder.getChildren().clear();
+        sessionLogPanelPlaceholder.getChildren().add(sessionLogPanel.getRoot());
+        showSessionLogPanel();
+    }
+
     /**
      * Injects the logs of the current person identified with their index in the address book
      * to the sessionLogPanel.
      */
-    public void handleLog(int personIndex) {
+    public void handleShowLog(int personIndex) {
         requireNonNull(personIndex);
         assert personIndex > -1 : "Person index retrieved is less than 0";
 
-        System.out.println(personIndex);
+        currentPersonLogIndex = personIndex;
         sessionLogPanel = new SessionLogPanel(logic.getSessionLog(personIndex));
-
 
         sessionLogPanelPlaceholder.getChildren().add(sessionLogPanel.getRoot());
         showSessionLogPanel();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -190,7 +190,7 @@ public class MainWindow extends UiPart<Stage> {
      * Opens the session log associated with the person with {@code personIndex}
      */
     private void handleShowSessionLogs(int personIndex) {
-        centralDisplay.handleLog(personIndex);
+        centralDisplay.handleShowLog(personIndex);
     }
 
 
@@ -217,11 +217,18 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            if (commandResult.isList()) {
+            if (commandResult.isListLogs()) {
                 handleShowSessionLogs(commandResult.getPersonIndex());
-            } else {
+            }
+
+            if (commandResult.isPersonList()) {
                 centralDisplay.showPersonListPanel();
             }
+
+            if (commandResult.isAddLog()) {
+                centralDisplay.handleLogRefresh(commandResult.getPersonIndex());
+            }
+
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,8 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false, -1)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false,
+                -1, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,16 +30,28 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false, -1)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false,
+                -1, false, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false, -1)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false,
+                -1, false, false)));
 
         // different list value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true, -1)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true,
+                -1, false, false)));
 
         //different personIndex value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false, 0)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
+                0, false, false)));
+
+        //different isPersonList value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
+                0, true, false)));
+
+        //different isAddLog value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
+                0, false, true)));
     }
 
     @Test
@@ -53,19 +66,27 @@ public class CommandResultTest {
 
         // different showHelp value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true,
-                false, false, false, -1).hashCode());
+                false, false, false, -1, false, false).hashCode());
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                true, false, false, -1).hashCode());
+                true, false, false, -1, false, false).hashCode());
 
         // different list value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, true, -1).hashCode());
+                false, false, true, -1, false, false).hashCode());
 
         // different personIndex value returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, false, 0).hashCode());
+                false, false, false, 0, false, false).hashCode());
+
+        //different isPersonList value -> returns false
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
+                false, false, false, 0, true, false).hashCode());
+
+        //different isAddLog value -> returns false
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
+                false, false, false, 0, false, true).hashCode());
     }
 
     @Test
@@ -75,8 +96,10 @@ public class CommandResultTest {
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
                 + ", exit=" + commandResult.isExit()
                 + ", prompt=" + commandResult.hasPrompt()
-                + ", list=" + commandResult.isList()
-                + ", personIndex=" + commandResult.getPersonIndex() + "}";
+                + ", list=" + commandResult.isListLogs()
+                + ", personIndex=" + commandResult.getPersonIndex()
+                + ", isPersonList=" + commandResult.isPersonList()
+                + ", isAddLog=" + commandResult.isAddLog() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -15,7 +15,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                false, true, false, false, -1);
+                false, true, false, false, -1, false, false);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,8 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false,
+                -1, false, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,12 +28,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,12 +28,14 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model, new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
+        assertCommandSuccess(new ListCommand(), model,
+                new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
     }
 }


### PR DESCRIPTION
closes #204 

The displayed gui for CentralDisplay does not change to person list or session log unless the command 
`list` or `logs` is used.

Additional logic implemented to refresh the session log ui when a new log is added and the current CentralDisplay shows the session log of the person we are trying to `addlog` to.