### PR TITLE
Revert "Add ability for ui to refresh upon adding a new log"

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddLogCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddLogCommand.java
@@ -47,11 +47,9 @@ public class AddLogCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         Person personToUpdate = getPerson(model);
-        int personIndex = model.getPersonList().indexOf(personToUpdate);
         model.addLog(personToUpdate, log);
 
-        return new CommandResult(String.format(MESSAGE_ADD_LOG_SUCCESS, personToUpdate.getName()),
-                false, false, false, false, personIndex, false, true);
+        return new CommandResult(String.format(MESSAGE_ADD_LOG_SUCCESS, personToUpdate.getName()));
     }
 
     private Person getPerson(Model model) throws CommandException {

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -20,16 +20,13 @@ public class CommandResult {
     private final boolean exit;
 
     /** The application should list the logs. */
-    private final boolean listLogs;
+    private final boolean list;
 
-    /** The application should list the person list. */
-    private final boolean isPersonList;
+    // ^ NEW: might not the best as well, but there is a need to bring out more information
+    // to the GUI layer so we can update and reflect the sessionlog. please think of a better way
 
-    /** The application should use the index returned. */
+    /** The application should use the index returned. */ // NEW: I dont think this is a good implementation.
     private final int personIndex;
-
-    /** The application should refresh the session log accordingly. */
-    private final boolean isAddLog;
 
     /** The previous command prompts the user for confirmation */
     private final boolean hasPrompt;
@@ -39,15 +36,13 @@ public class CommandResult {
      */
 
     public CommandResult(String feedbackToUser, boolean showHelp, boolean exit, boolean isPrompt,
-                         boolean list, int personIndex, boolean isPersonList, boolean isAddLog) {
+                         boolean list, int personIndex) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
         this.showHelp = showHelp;
         this.exit = exit;
-        this.listLogs = list;
+        this.list = list;
         this.personIndex = personIndex;
         this.hasPrompt = isPrompt;
-        this.isPersonList = isPersonList;
-        this.isAddLog = isAddLog;
     }
 
 
@@ -56,15 +51,7 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false, false, false, -1, false, false);
-    }
-
-    /**
-     * Constructs a {@code CommandResult} with the specified {@code feedbackToUser},
-     * and other fields set to their default value except {@code isPersonList} set to false.
-     */
-    public CommandResult(String feedbackToUser, boolean isPersonList) {
-        this(feedbackToUser, false, false, false, false, -1, isPersonList, false);
+        this(feedbackToUser, false, false, false, false, -1);
     }
 
     public String getFeedbackToUser() {
@@ -80,20 +67,13 @@ public class CommandResult {
     }
 
 
-    public boolean isListLogs() {
-        return listLogs;
+    public boolean isList() {
+        return list;
     }
 
+    // might need more validation to check if personIndex > -1 before retrieving?
     public int getPersonIndex() {
         return personIndex;
-    }
-
-    public boolean isAddLog() {
-        return isAddLog;
-    }
-
-    public boolean isPersonList() {
-        return isPersonList;
     }
 
 
@@ -116,16 +96,14 @@ public class CommandResult {
         return feedbackToUser.equals(otherCommandResult.feedbackToUser)
                 && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit
-                && listLogs == otherCommandResult.listLogs
+                && list == otherCommandResult.list
                 && personIndex == otherCommandResult.personIndex
-                && hasPrompt == otherCommandResult.hasPrompt
-                && isPersonList == otherCommandResult.isPersonList
-                && isAddLog == otherCommandResult.isAddLog;
+                && hasPrompt == otherCommandResult.hasPrompt;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit, listLogs, personIndex, hasPrompt, isPersonList, isAddLog);
+        return Objects.hash(feedbackToUser, showHelp, exit, list, personIndex, hasPrompt);
     }
 
     @Override
@@ -135,10 +113,8 @@ public class CommandResult {
                 .add("showHelp", showHelp)
                 .add("exit", exit)
                 .add("prompt", hasPrompt)
-                .add("list", listLogs)
+                .add("list", list)
                 .add("personIndex", personIndex)
-                .add("isPersonList", isPersonList)
-                .add("isAddLog", isAddLog)
                 .toString();
     }
 

--- a/src/main/java/seedu/address/logic/commands/ConfirmPrompt.java
+++ b/src/main/java/seedu/address/logic/commands/ConfirmPrompt.java
@@ -24,7 +24,7 @@ public class ConfirmPrompt extends Command {
         savedCommand.validateInput(model);
         model.setSavedCommand(savedCommand);
 
-        return new CommandResult(MESSAGE_CONFIRM_PROMPT, false, false, true, false, -1, false, false);
+        return new CommandResult(MESSAGE_CONFIRM_PROMPT, false, false, true, false, -1);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, -1, false, false);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true, false, false, -1);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1, false, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,7 +19,6 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, false, false,
-                false, false, -1, true, false);
+        return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListLogsCommand.java
@@ -71,7 +71,7 @@ public class ListLogsCommand extends Command {
         model.getSessionLog(personIndex);
         return new CommandResult(String.format(MESSAGE_LIST_LOG_SUCCESS,
                 person.getName(), identityNumber),
-                false, false, false, true, personIndex, false, false);
+                false, false, false, true, personIndex);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/CentralDisplay.java
+++ b/src/main/java/seedu/address/ui/CentralDisplay.java
@@ -15,11 +15,9 @@ public class CentralDisplay extends UiPart<Region> {
 
     private static final String FXML = "CentralDisplay.fxml";
 
-    private final Logic logic;
+    private Logic logic;
     private PersonListPanel personListPanel;
     private SessionLogPanel sessionLogPanel;
-
-    private int currentPersonLogIndex;
 
     @FXML
     private StackPane personListPanelPlaceholder;
@@ -78,34 +76,17 @@ public class CentralDisplay extends UiPart<Region> {
     }
 
 
-
-    /**
-     * Updates the session log whenever a new entry is added for the session log currently on display.
-     */
-    public void handleLogRefresh(int personIndex) {
-        requireNonNull(personIndex);
-        assert personIndex > -1 : "Person index retrieved is less than 0";
-
-        if (currentPersonLogIndex != personIndex || !sessionLogPanelPlaceholder.isVisible()) {
-            return;
-        }
-
-        sessionLogPanel = new SessionLogPanel(logic.getSessionLog(personIndex));
-        sessionLogPanelPlaceholder.getChildren().clear();
-        sessionLogPanelPlaceholder.getChildren().add(sessionLogPanel.getRoot());
-        showSessionLogPanel();
-    }
-
     /**
      * Injects the logs of the current person identified with their index in the address book
      * to the sessionLogPanel.
      */
-    public void handleShowLog(int personIndex) {
+    public void handleLog(int personIndex) {
         requireNonNull(personIndex);
         assert personIndex > -1 : "Person index retrieved is less than 0";
 
-        currentPersonLogIndex = personIndex;
+        System.out.println(personIndex);
         sessionLogPanel = new SessionLogPanel(logic.getSessionLog(personIndex));
+
 
         sessionLogPanelPlaceholder.getChildren().add(sessionLogPanel.getRoot());
         showSessionLogPanel();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -190,7 +190,7 @@ public class MainWindow extends UiPart<Stage> {
      * Opens the session log associated with the person with {@code personIndex}
      */
     private void handleShowSessionLogs(int personIndex) {
-        centralDisplay.handleShowLog(personIndex);
+        centralDisplay.handleLog(personIndex);
     }
 
 
@@ -217,18 +217,11 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-            if (commandResult.isListLogs()) {
+            if (commandResult.isList()) {
                 handleShowSessionLogs(commandResult.getPersonIndex());
-            }
-
-            if (commandResult.isPersonList()) {
+            } else {
                 centralDisplay.showPersonListPanel();
             }
-
-            if (commandResult.isAddLog()) {
-                centralDisplay.handleLogRefresh(commandResult.getPersonIndex());
-            }
-
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,8 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                -1, false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false, -1)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -30,28 +29,16 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false,
-                -1, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false, -1)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false,
-                -1, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false, -1)));
 
         // different list value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true,
-                -1, false, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true, -1)));
 
         //different personIndex value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                0, false, false)));
-
-        //different isPersonList value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                0, true, false)));
-
-        //different isAddLog value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                0, false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false, 0)));
     }
 
     @Test
@@ -66,27 +53,19 @@ public class CommandResultTest {
 
         // different showHelp value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true,
-                false, false, false, -1, false, false).hashCode());
+                false, false, false, -1).hashCode());
 
         // different exit value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                true, false, false, -1, false, false).hashCode());
+                true, false, false, -1).hashCode());
 
         // different list value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, true, -1, false, false).hashCode());
+                false, false, true, -1).hashCode());
 
         // different personIndex value returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, false, 0, false, false).hashCode());
-
-        //different isPersonList value -> returns false
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, false, 0, true, false).hashCode());
-
-        //different isAddLog value -> returns false
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false,
-                false, false, false, 0, false, true).hashCode());
+                false, false, false, 0).hashCode());
     }
 
     @Test
@@ -96,10 +75,8 @@ public class CommandResultTest {
                 + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
                 + ", exit=" + commandResult.isExit()
                 + ", prompt=" + commandResult.hasPrompt()
-                + ", list=" + commandResult.isListLogs()
-                + ", personIndex=" + commandResult.getPersonIndex()
-                + ", isPersonList=" + commandResult.isPersonList()
-                + ", isAddLog=" + commandResult.isAddLog() + "}";
+                + ", list=" + commandResult.isList()
+                + ", personIndex=" + commandResult.getPersonIndex() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -15,7 +15,7 @@ public class ExitCommandTest {
     @Test
     public void execute_exit_success() {
         CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT,
-                false, true, false, false, -1, false, false);
+                false, true, false, false, -1);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,8 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false,
-                -1, false, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false, false, false, -1);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListCommandTest.java
@@ -28,14 +28,12 @@ public class ListCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListCommand(), model,
-                new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListCommand(), model,
-                new CommandResult(ListCommand.MESSAGE_SUCCESS, true), expectedModel);
+        assertCommandSuccess(new ListCommand(), model, ListCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }


### PR DESCRIPTION
Reverts AY2425S1-CS2103T-W13-3/tp#252

Bugs
- Find command does not revert to person list
- Delete, edit command can still reference the person to change even though one is in logs view
- Deleting a specific person in the logs view don't reflect the logs view immediately

Suggestion
- Group all commands into either logs or people based and change the view accordingly regardless
> EG: successful addlog should auto switch to list view, without the need to use logs command

However this does not solve the fact where people can still reference model list when in logs view. Need to use ```isPeopleView && !isLogView``` to check and throw error 