### PR TITLE
Remove button to toggle between panels

### DIFF
--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -169,22 +169,6 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
-    /**
-     * Toggles the Central Display to show the Person List or the session logs.
-     */
-    @FXML
-    private void handleTogglePanel() {
-        if (centralDisplay.isPersonListVisible()) {
-            centralDisplay.showSessionLogPanel();
-            return;
-        }
-
-        if (centralDisplay.isSessionLogVisible()) {
-            centralDisplay.showPersonListPanel();
-            return;
-        }
-    }
-
 
     /**
      * Opens the session log associated with the person with {@code personIndex}

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -31,9 +31,6 @@
           <Menu mnemonicParsing="false" text="Help">
             <MenuItem fx:id="helpMenuItem" mnemonicParsing="false" onAction="#handleHelp" text="Help" />
           </Menu>
-          <Menu mnemonicParsing="false" text="Toggle">
-            <MenuItem fx:id="togglePanels" mnemonicParsing="false" onAction="#handleTogglePanel" text="Toggle Panel" />
-          </Menu>
         </MenuBar>
 
         <StackPane VBox.vgrow="NEVER" fx:id="commandBoxPlaceholder" styleClass="pane-with-border">


### PR DESCRIPTION
Removed the button to toggle between the two panels as it was more for testing rather than a full-on implementation.

The issue with the toggle button is that it does not update and refresh the ui components.

Also, given that this is a primarily CLI-based application, the commands `logs` is used to show the session log and any other command will display the contact/person list, making the toggle button mostly redundant.