### PR TITLE
Fix CommandResult equals and fix test cases

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -128,7 +128,7 @@ public class CommandResult {
                 && personIndex == otherCommandResult.personIndex
                 && hasPrompt == otherCommandResult.hasPrompt
                 && isPopup == otherCommandResult.isPopup
-                // Uses null safe equals method
+                // Uses null safe equals method since the following fields can be null
                 && Objects.equals(identityNumber, otherCommandResult.identityNumber)
                 && Objects.equals(appointmentDate, otherCommandResult.appointmentDate)
                 && Objects.equals(logEntry, otherCommandResult.logEntry);

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -112,11 +112,10 @@ public class CommandResult {
 
     @Override
     public boolean equals(Object other) {
-        if (other == this) {
+        if (this == other) {
             return true;
         }
 
-        // instanceof handles nulls
         if (!(other instanceof CommandResult)) {
             return false;
         }
@@ -127,14 +126,14 @@ public class CommandResult {
                 && exit == otherCommandResult.exit
                 && list == otherCommandResult.list
                 && personIndex == otherCommandResult.personIndex
-                && hasPrompt == otherCommandResult.hasPrompt;
-        /*
+                && hasPrompt == otherCommandResult.hasPrompt
                 && isPopup == otherCommandResult.isPopup
-                && identityNumber.equals(otherCommandResult.identityNumber)
-                && appointmentDate.equals(otherCommandResult.appointmentDate)
-                && logEntry.equals(otherCommandResult.logEntry);
-         */
+                // Uses null save equals method
+                && Objects.equals(identityNumber, otherCommandResult.identityNumber)
+                && Objects.equals(appointmentDate, otherCommandResult.appointmentDate)
+                && Objects.equals(logEntry, otherCommandResult.logEntry);
     }
+
 
     @Override
     public int hashCode() {
@@ -150,14 +149,11 @@ public class CommandResult {
                 .add("prompt", hasPrompt)
                 .add("list", list)
                 .add("personIndex", personIndex)
-                .toString();
-        /*
                 .add("isPopup", isPopup)
                 .add("identityNumber", identityNumber)
                 .add("appointmentDate", appointmentDate)
                 .add("logEntry", logEntry)
                 .toString();
-         */
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -128,7 +128,7 @@ public class CommandResult {
                 && personIndex == otherCommandResult.personIndex
                 && hasPrompt == otherCommandResult.hasPrompt
                 && isPopup == otherCommandResult.isPopup
-                // Uses null save equals method
+                // Uses null safe equals method
                 && Objects.equals(identityNumber, otherCommandResult.identityNumber)
                 && Objects.equals(appointmentDate, otherCommandResult.appointmentDate)
                 && Objects.equals(logEntry, otherCommandResult.logEntry);

--- a/src/main/java/seedu/address/model/log/LogEntry.java
+++ b/src/main/java/seedu/address/model/log/LogEntry.java
@@ -7,7 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LogEntry {
     public static final String MESSAGE_CONSTRAINTS = "Log description should not be blank.";
-    public static final String VALIDATION_REGEX = ".+";
+    public static final String VALIDATION_REGEX = "^(\\\\n|\\s)*$";
     private final String entry;
     private final String formattedEntry;
 
@@ -67,7 +67,7 @@ public class LogEntry {
      * Returns true if a given string is a valid entry.
      */
     public static boolean isValidEntry(String test) {
-        return test.matches(VALIDATION_REGEX);
+        return !test.matches(VALIDATION_REGEX);
     }
 
     @Override

--- a/src/main/java/seedu/address/model/log/LogEntry.java
+++ b/src/main/java/seedu/address/model/log/LogEntry.java
@@ -64,7 +64,7 @@ public class LogEntry {
 
     }
 
-   /**
+    /**
      * Converts the storage entry to a formatted string.
      */
     public static String convertToFormattedString(String storageEntry) {

--- a/src/main/java/seedu/address/model/log/LogEntry.java
+++ b/src/main/java/seedu/address/model/log/LogEntry.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  */
 public class LogEntry {
     public static final String MESSAGE_CONSTRAINTS = "Log description should not be blank.";
+    // Validation regex represents a string that contains only new line or whitespace characters
     public static final String VALIDATION_REGEX = "^(\\\\n|\\s)*$";
     private final String entry;
     private final String formattedEntry;
@@ -47,13 +48,32 @@ public class LogEntry {
         return formattedEntry;
     }
 
+    /**
+     * Converts the log entry to a storage string. It is also safe to be passed a argument to any command.
+     */
     public static String convertToStorageString(String formattedEntry) {
-        return formattedEntry.replace("\n", "\\n");
+        // Replaces all tags with special characters to prevent conflicts with the parser
+        // \n is converted into NEWLINE, before converting back to counter edge case where users
+        // types a new line character within the replacement character for tags.
+        // Eg: #i\n$ will not be converted properly.
+        return formattedEntry.replace("\n", "{NEWLINE}")
+                .replace("i/", "#i$")
+                .replace("d/", "#d$")
+                .replace("l/", "#l$")
+                .replace("{NEWLINE}", "\\n");
+
     }
 
+   /**
+     * Converts the storage entry to a formatted string.
+     */
     public static String convertToFormattedString(String storageEntry) {
-        return storageEntry.replace("\\n", "\n");
+        return storageEntry.replace("#l$", "l/")
+                .replace("#d$", "d/")
+                .replace("#i$", "i/")
+                .replace("\\n", "\n");
     }
+
     /**
      * Returns the formatted truncated log entry.
      */
@@ -70,6 +90,9 @@ public class LogEntry {
         return !test.matches(VALIDATION_REGEX);
     }
 
+    /**
+     * Returns true if both log entries are the same.
+     */
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
@@ -77,6 +100,9 @@ public class LogEntry {
                 && entry.equals(((LogEntry) other).entry)); // state check
     }
 
+    /**
+     * Returns the hashcode of the log entry.
+     */
     @Override
     public int hashCode() {
         return entry.hashCode();

--- a/src/main/java/seedu/address/ui/AddLogPopup.java
+++ b/src/main/java/seedu/address/ui/AddLogPopup.java
@@ -18,6 +18,7 @@ import seedu.address.model.log.LogEntry;
 public class AddLogPopup extends UiPart<Stage> {
 
     private static final String FXML = "AddLogPopup.fxml";
+
     /**
      * Constructs a UiPart using the specified FXML file within {@link #FXML_FILE_FOLDER}.
      *
@@ -39,7 +40,7 @@ public class AddLogPopup extends UiPart<Stage> {
 
         TextArea logEntryArea = new TextArea();
         logEntryArea.setPromptText("Enter your log entry here...");
-        logEntryArea.setWrapText(true); // Enable wrapping without new lines
+        logEntryArea.setWrapText(true);
 
         VBox.setVgrow(logEntryArea, Priority.ALWAYS);
 
@@ -47,7 +48,8 @@ public class AddLogPopup extends UiPart<Stage> {
         saveButton.setDisable(true);
 
         logEntryArea.textProperty().addListener((observable, oldValue, newValue) -> {
-            saveButton.setDisable(newValue.trim().isEmpty());
+            String trimmedText = newValue.trim();
+            saveButton.setDisable(trimmedText.isEmpty() || trimmedText.matches("^(\\\\n|\\s)*$"));
         });
 
         final String[] logEntry = {null}; // Capture log entry result

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -7,44 +7,74 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
 
+import seedu.address.model.log.AppointmentDate;
+import seedu.address.model.person.IdentityNumber;
+
 public class CommandResultTest {
     @Test
     public void equals() {
         CommandResult commandResult = new CommandResult("feedback");
 
-        // same values -> returns true
+        // Same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                -1, false, null, null, null)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false, false, -1,
+                false, null, null, null)));
 
-        // same object -> returns true
+        // Same object -> returns true
         assertTrue(commandResult.equals(commandResult));
 
-        // null -> returns false
+        // Null -> returns false
         assertFalse(commandResult.equals(null));
 
-        // different types -> returns false
+        // Different type -> returns false
         assertFalse(commandResult.equals(0.5f));
 
-        // different feedbackToUser value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("different")));
+        // Different feedbackToUser value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "different", false, false, false, false, -1,
+                false, null, null, null)));
 
-        // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false, false,
-                -1, false, null, null, null)));
+        // Different showHelp value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", true, false, false, false, -1,
+                false, null, null, null)));
 
-        // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false, false,
-                -1, false, null, null, null)));
+        // Different exit value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, true, false, false, -1,
+                false, null, null, null)));
 
-        // different list value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, true,
-                -1, false, null, null, null)));
+        // Different list value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, true, -1,
+                false, null, null, null)));
 
-        //different personIndex value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, false, false,
-                0, false, null, null, null)));;
+        // Different personIndex value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, false, 0,
+                false, null, null, null)));
+
+        // Different isPopup value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, false, -1,
+                true, null, null, null)));
+
+        // Different identityNumber value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, false, -1,
+                false, new IdentityNumber("S0000001I"), null, null)));
+
+        // Different appointmentDate value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, false, -1,
+                false, null, new AppointmentDate("01 JAN 2024"), null)));
+
+        // Different logEntry value -> returns false
+        assertFalse(commandResult.equals(new CommandResult(
+                "feedback", false, false, false, false, -1,
+                false, null, null, "Different log entry")));
     }
+
 
     @Test
     public void hashcode() {
@@ -75,13 +105,33 @@ public class CommandResultTest {
 
     @Test
     public void toStringMethod() {
-        CommandResult commandResult = new CommandResult("feedback");
-        String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
-                + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
+        CommandResult commandResult = new CommandResult(
+                "feedback",
+                true,
+                false,
+                false,
+                false,
+                1,
+                true,
+                new IdentityNumber("S0000001I"),
+                new AppointmentDate("01 JAN 2024"),
+                "Entry log"
+        );
+
+        String expected = CommandResult.class.getCanonicalName()
+                + "{feedbackToUser=" + commandResult.getFeedbackToUser()
+                + ", showHelp=" + commandResult.isShowHelp()
                 + ", exit=" + commandResult.isExit()
                 + ", prompt=" + commandResult.hasPrompt()
                 + ", list=" + commandResult.isList()
-                + ", personIndex=" + commandResult.getPersonIndex() + "}";
+                + ", personIndex=" + commandResult.getPersonIndex()
+                + ", isPopup=" + commandResult.isPopup()
+                + ", identityNumber=" + commandResult.getIdentityNumber()
+                + ", appointmentDate=" + commandResult.getAppointmentDate()
+                + ", logEntry=" + commandResult.getLogEntry()
+                + "}";
+
         assertEquals(expected, commandResult.toString());
     }
+
 }


### PR DESCRIPTION
Closes #336 #334 

Fixes:
1) Equals method in CommandResult as well as test cases.
2) Prevents uses from entering purely new line characters to make it seem like log is empty
3) i/ d/ and l/ flags can now be used in log entry

![image](https://github.com/user-attachments/assets/022c3d82-baec-44d1-9726-4642111fcd82)
![image](https://github.com/user-attachments/assets/cd1ea8fa-455a-40e6-ae86-eb44c236f86e)
